### PR TITLE
feat: validar creación de pacientes con DNI único

### DIFF
--- a/src/main/java/com/teamcubation/api/pacientes/controller/PacienteController.java
+++ b/src/main/java/com/teamcubation/api/pacientes/controller/PacienteController.java
@@ -2,11 +2,14 @@ package com.teamcubation.api.pacientes.controller;
 
 import com.teamcubation.api.pacientes.dto.PacienteRequest;
 import com.teamcubation.api.pacientes.dto.PacienteResponse;
+import com.teamcubation.api.pacientes.mapper.PacienteMapper;
+import com.teamcubation.api.pacientes.model.Paciente;
 import com.teamcubation.api.pacientes.service.PacienteService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -15,38 +18,46 @@ public class PacienteController {
 
     private final PacienteService pacienteService;
 
-    public PacienteController(PacienteService pacienteService) {
+    public PacienteController(PacienteService pacienteService, PacienteMapper pacienteMapper) {
         this.pacienteService = pacienteService;
     }
 
     @PostMapping
-    public ResponseEntity<PacienteResponse> crearPaciente(@RequestBody PacienteRequest request) {
-        PacienteResponse paciente = this.pacienteService.crearPaciente(request);
-        return new ResponseEntity<>(paciente, HttpStatus.CREATED);
+    public ResponseEntity<PacienteResponse> crear(@RequestBody PacienteRequest request) {
+        Paciente paciente = PacienteMapper.toEntity(request);
+        Paciente creado = this.pacienteService.crear(paciente);
+        return ResponseEntity.status(HttpStatus.CREATED).body(PacienteMapper.toResponse(creado));
     }
 
     @GetMapping
-    public ResponseEntity<List<PacienteResponse>> obtenerPacientes() {
-        List<PacienteResponse> pacientes = this.pacienteService.obtenerPacientes();
-        return new ResponseEntity<>(pacientes, HttpStatus.OK);
+    public ResponseEntity<List<PacienteResponse>> obtenerTodos(@RequestParam(required = false) String dni,
+                                                               @RequestParam(required = false) String nombre) {
+        List<Paciente> pacientes = this.pacienteService.obtenerTodos(dni, nombre);
+        List<PacienteResponse> response = new ArrayList<>();
+        for(Paciente paciente : pacientes) {
+            response.add(PacienteMapper.toResponse(paciente));
+        }
+        return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PacienteResponse> obtenerPaciente(@PathVariable Long id) {
-        PacienteResponse paciente = this.pacienteService.obtenerPacientePorId(id);
-        return new ResponseEntity<>(paciente, HttpStatus.OK);
+    public ResponseEntity<PacienteResponse> obtenerPorID(@PathVariable long id) {
+        Paciente paciente = this.pacienteService.obtenerPorID(id);
+        return ResponseEntity.ok().body(PacienteMapper.toResponse(paciente));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<PacienteResponse> actualizarPaciente(@PathVariable Long id, @RequestBody PacienteRequest request) {
-        PacienteResponse paciente = this.pacienteService.actualizarPaciente(id, request);
-        return new ResponseEntity<>(paciente, HttpStatus.OK);
+    public ResponseEntity<PacienteResponse> actualizarPorID(@PathVariable long id,
+                                                            @RequestBody PacienteRequest request) {
+        Paciente paciente = PacienteMapper.toEntity(request);
+        Paciente response = this.pacienteService.actualizarPorID(id, paciente);
+        return ResponseEntity.ok().body(PacienteMapper.toResponse(response));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Object> borrarPaciente(@PathVariable Long id) {
-        this.pacienteService.borrarPaciente(id);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    public ResponseEntity<Void> borrarPorID(@PathVariable long id) {
+        this.pacienteService.borrarPorID(id);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/teamcubation/api/pacientes/mapper/PacienteMapper.java
+++ b/src/main/java/com/teamcubation/api/pacientes/mapper/PacienteMapper.java
@@ -1,0 +1,30 @@
+package com.teamcubation.api.pacientes.mapper;
+
+import com.teamcubation.api.pacientes.dto.PacienteRequest;
+import com.teamcubation.api.pacientes.dto.PacienteResponse;
+import com.teamcubation.api.pacientes.model.Paciente;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PacienteMapper {
+    public static Paciente toEntity(PacienteRequest request) {
+        Paciente paciente = new Paciente();
+        paciente.setNombre(request.getNombre());
+        paciente.setApellido(request.getApellido());
+        paciente.setDni(request.getDni());
+        paciente.setObraSocial(request.getObraSocial());
+        paciente.setEmail(request.getEmail());
+        paciente.setTelefono(request.getTelefono());
+        return paciente;
+    }
+
+    public static PacienteResponse toResponse(Paciente p) {
+        PacienteResponse response = new PacienteResponse();
+        response.setId(p.getId());
+        response.setNombre(p.getNombre());
+        response.setApellido(p.getApellido());
+        response.setDni(p.getDni());
+        return response;
+    }
+
+}

--- a/src/main/java/com/teamcubation/api/pacientes/repository/IPacienteRepository.java
+++ b/src/main/java/com/teamcubation/api/pacientes/repository/IPacienteRepository.java
@@ -7,9 +7,9 @@ import java.util.Optional;
 
 public interface IPacienteRepository {
     Paciente guardar(Paciente paciente);
-    Optional<Paciente> buscarPorId(Long id);
+    Optional<Paciente> buscarPorID(Long id);
     Optional<Paciente> buscarPorDNI(String dni);
-    List<Paciente> buscarTodos();
-    Paciente actualizar(Paciente paciente);
-    boolean borrar(Long id);
+    List<Paciente> buscarTodos(String dni, String nombre);
+    Paciente actualizarPorID(Long id, Paciente paciente);
+    void borrarPorID(Long id);
 }

--- a/src/main/java/com/teamcubation/api/pacientes/service/IPacienteService.java
+++ b/src/main/java/com/teamcubation/api/pacientes/service/IPacienteService.java
@@ -1,14 +1,13 @@
 package com.teamcubation.api.pacientes.service;
 
-import com.teamcubation.api.pacientes.dto.PacienteRequest;
-import com.teamcubation.api.pacientes.dto.PacienteResponse;
+import com.teamcubation.api.pacientes.model.Paciente;
 
 import java.util.List;
 
 public interface IPacienteService {
-    PacienteResponse crearPaciente(PacienteRequest request);
-    List<PacienteResponse> obtenerPacientes();
-    PacienteResponse obtenerPacientePorId(Long id);
-    PacienteResponse actualizarPaciente(Long id, PacienteRequest request);
-    void borrarPaciente(Long id);
+    Paciente crear(Paciente request);
+    List<Paciente> obtenerTodos(String dni, String nombre);
+    Paciente obtenerPorID(long id);
+    Paciente actualizarPorID(long id, Paciente paciente);
+    void borrarPorID(long id);
 }

--- a/src/main/java/com/teamcubation/api/pacientes/service/PacienteService.java
+++ b/src/main/java/com/teamcubation/api/pacientes/service/PacienteService.java
@@ -1,15 +1,11 @@
 package com.teamcubation.api.pacientes.service;
 
-import com.teamcubation.api.pacientes.dto.PacienteRequest;
-import com.teamcubation.api.pacientes.dto.PacienteResponse;
 import com.teamcubation.api.pacientes.exception.PacienteDuplicadoException;
 import com.teamcubation.api.pacientes.exception.PacienteNoEncontradoException;
 import com.teamcubation.api.pacientes.model.Paciente;
-import com.teamcubation.api.pacientes.repository.IPacienteRepository;
 import com.teamcubation.api.pacientes.repository.PacienteRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,90 +13,74 @@ import java.util.Optional;
 public class PacienteService implements IPacienteService {
 
     private final PacienteRepository pacienteRepository;
-    private static final String PACIENTE_DUPLICADO_ERROR = "DNI";
+    private static final String CAMPO_DNI = "DNI";
 
     public PacienteService(PacienteRepository pacienteRepository) {
         this.pacienteRepository = pacienteRepository;
     }
 
     @Override
-    public PacienteResponse crearPaciente(PacienteRequest request) {
-        Optional<Paciente> existente = pacienteRepository.buscarPorDNI(request.getDni());
+    public Paciente crear(Paciente paciente) {
+        Optional<Paciente> existente = pacienteRepository.buscarPorDNI(paciente.getDni());
 
         if (existente.isPresent()) {
-            throw new PacienteDuplicadoException(PACIENTE_DUPLICADO_ERROR, request.getDni());
+            throw new PacienteDuplicadoException(CAMPO_DNI, paciente.getDni());
         }
-
-        Paciente paciente = mapToEntity(request);
-        Paciente pacienteGuardado = pacienteRepository.guardar(paciente);
-        return mapToResponse(pacienteGuardado);
+        return pacienteRepository.guardar(paciente);
     }
 
     @Override
-    public List<PacienteResponse> obtenerPacientes() {
-        List<Paciente> pacientes = this.pacienteRepository.buscarTodos();
-        List<PacienteResponse> response = new ArrayList<>();
-        for (Paciente paciente : pacientes) {
-            PacienteResponse pacienteResponse = mapToResponse(paciente);
-            response.add(pacienteResponse);
-        }
-        return response;
+    public List<Paciente> obtenerTodos(String dni, String nombre) {
+        return this.pacienteRepository.buscarTodos(dni, nombre);
     }
 
     @Override
-    public PacienteResponse obtenerPacientePorId(Long id) {
-        Paciente paciente = this.pacienteRepository.buscarPorId(id)
+    public Paciente obtenerPorID(long id) {
+        return this.pacienteRepository.buscarPorID(id)
                 .orElseThrow(() -> new PacienteNoEncontradoException(id));
-        return mapToResponse(paciente);
     }
 
     @Override
-    public PacienteResponse actualizarPaciente(Long id, PacienteRequest request) {
-        Paciente paciente = pacienteRepository.buscarPorId(id)
+    public Paciente actualizarPorID(long id, Paciente paciente) {
+        Paciente existente = pacienteRepository.buscarPorID(id)
                 .orElseThrow(() -> new PacienteNoEncontradoException(id));
 
-        copiarCamposNoNulos(request, paciente);
+        if (paciente.getDni() != null) {
+            Optional<Paciente> pacienteDNIDuplicado = pacienteRepository.buscarPorDNI(paciente.getDni());
+            boolean dniUsadoPorOtro = pacienteDNIDuplicado.isPresent() && !pacienteDNIDuplicado.get().getId().equals(id);
+            if (dniUsadoPorOtro) {
+                throw new PacienteDuplicadoException(CAMPO_DNI, paciente.getDni());
+            }
+        }
 
-        Paciente pacienteActualizado = pacienteRepository.actualizar(paciente);
-
-        return mapToResponse(pacienteActualizado);
+        copiarCamposNoNulos(paciente, existente);
+        return pacienteRepository.actualizarPorID(id, paciente);
     }
 
     @Override
-    public void borrarPaciente(Long id) {
-        boolean borrado = pacienteRepository.borrar(id);
-
-        if (!borrado) {
-            throw new PacienteNoEncontradoException(id);
-        }
+    public void borrarPorID(long id) {
+        pacienteRepository.buscarPorID(id)
+                .orElseThrow(() -> new PacienteNoEncontradoException(id));
+        pacienteRepository.borrarPorID(id);
     }
 
-    private Paciente mapToEntity(PacienteRequest request) {
-        Paciente paciente = new Paciente();
-        paciente.setNombre(request.getNombre());
-        paciente.setApellido(request.getApellido());
-        paciente.setDni(request.getDni());
-        paciente.setObraSocial(request.getObraSocial());
-        paciente.setEmail(request.getEmail());
-        paciente.setTelefono(request.getTelefono());
-        return paciente;
-    }
-
-    private PacienteResponse mapToResponse(Paciente p) {
-        PacienteResponse pacienteResponse = new PacienteResponse();
-        pacienteResponse.setId(p.getId());
-        pacienteResponse.setNombre(p.getNombre());
-        pacienteResponse.setApellido(p.getApellido());
-        pacienteResponse.setDni(p.getDni());
-        return pacienteResponse;
-    }
-
-    private void copiarCamposNoNulos(PacienteRequest request, Paciente paciente) {
-        if (request.getNombre() != null) paciente.setNombre(request.getNombre());
-        if (request.getApellido() != null) paciente.setApellido(request.getApellido());
-        if (request.getDni() != null) paciente.setDni(request.getDni());
-        if (request.getObraSocial() != null) paciente.setObraSocial(request.getObraSocial());
-        if (request.getEmail() != null) paciente.setEmail(request.getEmail());
-        if (request.getTelefono() != null) paciente.setTelefono(request.getTelefono());
+    /**
+     * Copia solo los campos no nulos desde el objeto de datos actualizados hacia el paciente existente.
+     *
+     * Este método permite realizar una actualización parcial del paciente,
+     * manteniendo los valores originales de aquellos campos que no fueron modificados.
+     *
+     * Es útil en operaciones donde no se requiere sobrescribir todos los datos.
+     *
+     * @param datosActualizados Objeto que contiene los nuevos valores (puede tener campos nulos).
+     * @param pacienteExistente Entidad persistida a la que se le aplicarán los cambios no nulos.
+     */
+    private void copiarCamposNoNulos(Paciente datosActualizados, Paciente pacienteExistente) {
+        if (datosActualizados.getNombre() != null) pacienteExistente.setNombre(datosActualizados.getNombre());
+        if (datosActualizados.getApellido() != null) pacienteExistente.setApellido(datosActualizados.getApellido());
+        if (datosActualizados.getDni() != null) pacienteExistente.setDni(datosActualizados.getDni());
+        if (datosActualizados.getObraSocial() != null) pacienteExistente.setObraSocial(datosActualizados.getObraSocial());
+        if (datosActualizados.getEmail() != null) pacienteExistente.setEmail(datosActualizados.getEmail());
+        if (datosActualizados.getTelefono() != null) pacienteExistente.setTelefono(datosActualizados.getTelefono());
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+INSERT INTO pacientes (nombre, apellido, dni, obra_social, email, telefono) VALUES
+('Juan', 'Pérez', '12345678', 'Swiss Medical', 'juan.perez@mail.com', '1122334455'),
+('Juan', 'Gómez', '87654321', 'Swiss Medical', 'juan.gomez@mail.com', '1199887766'),
+('Ana', 'Rodríguez', '45678912', 'Swiss Medical', 'ana.rodriguez@mail.com', '1144556677'),
+('Ana', 'Fernández', '23456789', 'Swiss Medical', 'ana.fernandez@mail.com', '1166778899'),
+('María', 'Martínez', '34567890', 'Swiss Medical', 'maria.martinez@mail.com', '1177889900'),
+('María', 'López', '56789012', 'Swiss Medical', 'maria.lopez@mail.com', '1188990011'),
+('Diego', 'Sánchez', '67890123', 'Swiss Medical', 'diego.sanchez@mail.com', '1199001122'),
+('Diego', 'Torres', '78901234', 'Swiss Medical', 'diego.torres@mail.com', '1100112233'),
+('Martín', 'Ramírez', '89012345', 'Swiss Medical', 'martin.ramirez@mail.com', '1111223344'),
+('Martín', 'Vargas', '90123456', 'Swiss Medical', 'martin.vargas@mail.com', '1122334455');


### PR DESCRIPTION
- Se agrega validación para evitar la creación de pacientes con DNI duplicado.
- Se lanza excepción personalizada PacienteDuplicadoException si ya existe un paciente con el mismo DNI.
- Se implementa método buscarPorDNI en el repositorio.