### PR TITLE
Spring Boot Actuator para monitoreo

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,17 @@ Este proyecto muestra cómo aplicar de forma combinada el **Principio de Respons
 - ✅ Los componentes están desacoplados entre sí.
 - ✅ El sistema puede extenderse sin necesidad de modificar las clases existentes.
 
+---
+
+# 🩺 Health Check con Spring Boot Actuator
+
+Este microservicio utiliza Spring Boot Actuator para exponer un endpoint de salud que permite verificar si el servicio está funcionando correctamente.
+
+El endpoint principal es: 
+- `GET /actuator/health`
+
+También se exponen métricas de la aplicación a través del endpoint:
+
+- `GET /actuator/metrics`
+
+Esto permite observar información como el uso de CPU, memoria, cantidad de peticiones HTTP, estado del pool de conexiones, entre otros.

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <springdoc.openapi.version>2.8.9</springdoc.openapi.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -61,7 +62,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>3.5.3</version>
         </dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.8.9</version>
+			<version>${springdoc.openapi.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.5.3</version>
+        </dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ logging.level.PACIENTE-LOGS=INFO
 logging.level.SISTEMA-LOGS=WARN
 
 trafico.alerta.threshold=1
+
+management.endpoints.web.exposure.include=health,metrics
+management.endpoint.health.show-details=always


### PR DESCRIPTION
- Se incorporó la dependencia spring-boot-starter-actuator en el pom.xml.

- Se habilitaron los endpoints `/actuator/health`  y  `/actuator/metrics` desde application.properties.

- Se actualizó el archivo README.md con una explicación breve del uso de Actuator.